### PR TITLE
Specify bundler 2.0.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,4 +86,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   2.0.1
+   2.0.2


### PR DESCRIPTION
Update `Gemfile.lock` so that it points to a heroku-approved version of bundler.